### PR TITLE
fix background color opacity

### DIFF
--- a/app/themes/halloween.json
+++ b/app/themes/halloween.json
@@ -3,7 +3,7 @@
     "themeName": "halloween",
     "theme": {
         "seriesCnt": "4",
-        "backgroundColor": "rgba(64,64,64,0.5)",
+        "backgroundColor": "rgba(64,64,64,1)",
         "titleColor": "#ffaf51",
         "subtitleColor": "#eeeeee",
         "textColorShow": false,


### PR DESCRIPTION
![Screenshot from 2024-04-17 20-51-40](https://github.com/apache/echarts-theme-builder/assets/68921363/d8ddd3f2-4201-4fbe-9aea-7415ffc4c721)

due to 0.5 opacity the background colors were messed up, so after changing its default value to 1, it looks great

![Screenshot from 2024-04-17 20-51-51](https://github.com/apache/echarts-theme-builder/assets/68921363/ca45be0d-e16c-4af0-aa95-bb3f20d7af6e)
